### PR TITLE
Correct reference hint path pattern and replacement

### DIFF
--- a/TemplatesVSIX/Trados/Patches/HintPathPatch.cs
+++ b/TemplatesVSIX/Trados/Patches/HintPathPatch.cs
@@ -30,8 +30,8 @@ namespace TemplatesVSIX.Trados.Patches
         {
             reference.HintPath = Regex.Replace(
                 reference.HintPath,
-                @"(\\Trados\\Trados Studio\\)Studio\d{1,2}",
-                "$1Studio" + _newVersion);
+                @"(\(ProgramFiles\)\\SDL\\SDL Trados Studio\\)Studio\d{1,2}",
+                @"(MSBuildProgramFiles32)\Trados\Trados Studio\Studio" + _newVersion);
         }
     }
 }


### PR DESCRIPTION
 - previous version had "SDL" in it so the pattern had to be changed
 - VS 2022 sees $(ProgramFiles) as the 64 bit version; changed to $(MSBuildPProgramFiles32)