### PR TITLE
LG-29903 - Use new plugin build nuget.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -211,3 +211,5 @@ IATETerminologyProvider/IATETerminologyProvider/pluginpackage.manifest_REMOTE_17
 IATETerminologyProvider/IATETerminologyProvider/pluginpackage.manifest_BASE_17888.xml
 IATETerminologyProvider/IATETerminologyProvider/pluginpackage.manifest_BACKUP_17888.xml
 IATETerminologyProvider/IATETerminologyProvider/pluginpackage.manifest_LOCAL_17888.xml
+
+.vscode

--- a/TemplatesVSIX/SDL Custom Batch Task/ProjectTemplate.csproj
+++ b/TemplatesVSIX/SDL Custom Batch Task/ProjectTemplate.csproj
@@ -54,7 +54,7 @@
 			<Version>2.1.0</Version>
 		</PackageReference>
 		<PackageReference Include="Sdl.Core.PluginFramework.Build">
-			<Version>16.1.0</Version>
+			<Version>17.0.0</Version>
 		</PackageReference>
 	</ItemGroup>
   <PropertyGroup>

--- a/TemplatesVSIX/SDL Custom Batch Task/SDL Custom Batch Task.vstemplate
+++ b/TemplatesVSIX/SDL Custom Batch Task/SDL Custom Batch Task.vstemplate
@@ -31,7 +31,7 @@
   <WizardData>
 	<packages repository="extension" repositoryId="829d11b0-cae5-4938-aad6-c8366b63fef5">
 		<package id="Sdl.Core.PluginFramework" version="2.1.0" />
-		<package id="Sdl.Core.PluginFramework.Build" version="16.1.0" />
+		<package id="Sdl.Core.PluginFramework.Build" version="17.0.0" />
 	</packages>
   </WizardData>
 </VSTemplate>

--- a/TemplatesVSIX/SDL Terminology Provider/ProjectTemplate.csproj
+++ b/TemplatesVSIX/SDL Terminology Provider/ProjectTemplate.csproj
@@ -58,7 +58,7 @@
 			<Version>2.1.0</Version>
 		</PackageReference>
 		<PackageReference Include="Sdl.Core.PluginFramework.Build">
-			<Version>16.1.0</Version>
+			<Version>17.0.0</Version>
 		</PackageReference>
 	</ItemGroup>
   <PropertyGroup>

--- a/TemplatesVSIX/SDL Terminology Provider/SDL Terminology Provider.vstemplate
+++ b/TemplatesVSIX/SDL Terminology Provider/SDL Terminology Provider.vstemplate
@@ -31,7 +31,7 @@
   <WizardData>
 	<packages repository="extension" repositoryId="829d11b0-cae5-4938-aad6-c8366b63fef5">
 		<package id="Sdl.Core.PluginFramework" version="2.1.0" />
-		<package id="Sdl.Core.PluginFramework.Build" version="16.1.0" />
+		<package id="Sdl.Core.PluginFramework.Build" version="17.0.0" />
 	</packages>
   </WizardData>
 </VSTemplate>

--- a/TemplatesVSIX/SDL Trados Studio/ProjectTemplate.csproj
+++ b/TemplatesVSIX/SDL Trados Studio/ProjectTemplate.csproj
@@ -63,7 +63,7 @@
   		<Version>2.1.0</Version>
   	</PackageReference>
   	<PackageReference Include="Sdl.Core.PluginFramework.Build">
-  		<Version>16.1.0</Version>
+  		<Version>17.0.0</Version>
   	</PackageReference>
   </ItemGroup>
   <PropertyGroup>

--- a/TemplatesVSIX/SDL Trados Studio/SDL Trados Studio.vstemplate
+++ b/TemplatesVSIX/SDL Trados Studio/SDL Trados Studio.vstemplate
@@ -28,7 +28,7 @@
   <WizardData>
 	<packages repository="extension" repositoryId="829d11b0-cae5-4938-aad6-c8366b63fef5">
 		<package id="Sdl.Core.PluginFramework" version="2.1.0" />
-		<package id="Sdl.Core.PluginFramework.Build" version="16.1.0" />
+		<package id="Sdl.Core.PluginFramework.Build" version="17.0.0" />
 	</packages>
   </WizardData>
 </VSTemplate>

--- a/TemplatesVSIX/SDL Translation Provider/ProjectTemplate.csproj
+++ b/TemplatesVSIX/SDL Translation Provider/ProjectTemplate.csproj
@@ -49,7 +49,7 @@
   		<Version>2.1.0</Version>
   	</PackageReference>
   	<PackageReference Include="Sdl.Core.PluginFramework.Build">
-  		<Version>16.1.0</Version>
+  		<Version>17.0.0</Version>
   	</PackageReference>
   </ItemGroup>
   <PropertyGroup>

--- a/TemplatesVSIX/SDL Translation Provider/SDL Translation Provider.vstemplate
+++ b/TemplatesVSIX/SDL Translation Provider/SDL Translation Provider.vstemplate
@@ -31,7 +31,7 @@
   <WizardData>
 	<packages repository="extension" repositoryId="829d11b0-cae5-4938-aad6-c8366b63fef5">
 		<package id="Sdl.Core.PluginFramework" version="2.1.0" />
-		<package id="Sdl.Core.PluginFramework.Build" version="16.1.0" />
+		<package id="Sdl.Core.PluginFramework.Build" version="17.0.0" />
 	</packages>
   </WizardData>
 </VSTemplate>


### PR DESCRIPTION
The templates should use the new plugin framework build NuGet package to validate correctly for Trados Studio 2022.